### PR TITLE
Add `socket.io-client` as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "commander": "1",
-    "ws": "0.4"
+    "ws": "0.4",
+    "socket.io-client": "1.3.4"
   },
   "devDependencies": {
   },


### PR DESCRIPTION
I tried to use `iocat` with the `--socketio` tag and it broke, as `socket.io-client` was not already installed. Listing it as a dependency in the `package.json` should fix this.